### PR TITLE
Update to aas-core-meta, codegen, testgen 3191ea5, 9b47d57, 1788d59c

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ pylint==2.15.4
 coverage>=6.5.0,<7
 pyinstaller>=5<6
 twine
-aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@9ccd31e#egg=aas-core-meta
-aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@0f287d2#egg=aas-core-codegen
+aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@3191ea5#egg=aas-core-meta
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@9b47d57#egg=aas-core-codegen


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 3191ea5],
* [aas-core-codegen 9b47d57] and
* [aas-core3.0-testgen 1788d59c].

[aas-core-meta 3191ea5]: https://github.com/aas-core-works/aas-core-meta/commit/3191ea5
[aas-core-codegen 9b47d57]: https://github.com/aas-core-works/aas-core-codegen/commit/9b47d57
[aas-core3.0-testgen 1788d59c]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/1788d59c