### PR TITLE
Release 1.0.0rc2

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate, verify and de/serialize Asset Administration Shells."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0rc2"
 __author__ = "Marko Ristin"
 __copyright__ = "2023 Contributors to aas-core3.0-python"
 __license__ = "License :: OSI Approved :: MIT License"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,17 @@
 Change Log
 **********
 
+1.0.0rc2 (2023-06-28)
+=====================
+* Update to aas-core-meta, codegen, testgen 44756fb, 607f65c,
+  bf3720d7 (#7)
+  *  This is an important patch propagating in particular the following fixes
+    which affected the constraints and their documentation:
+    * Pull requests in aas-core-meta 271, 272 and 273 which affect the
+      nullability checks in constraints,
+    * Pull request in aas-core-meta 275 which affects the documentation
+      of many constraints.
+
 1.0.0rc1 (2023-03-03)
-=======================
+=====================
 * Initial version

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="aas-core3.0",
     # Synchronize with __init__.py and changelog.rst!
-    version="1.0.0rc1",
+    version="1.0.0rc2",
     description="Manipulate, verify and de/serialize Asset Administration Shells.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0-python",


### PR DESCRIPTION
* Update to aas-core-meta, codegen, testgen 44756fb, 607f65c, bf3720d7 (#7)

  *  This is an important patch propagating in particular the following fixes which affected the constraints and their documentation:

    * Pull requests in aas-core-meta 271, 272 and 273 which affect the nullability checks in constraints,

    * Pull request in aas-core-meta 275 which affects the documentation of many constraints.