### PR TITLE
Update to aas-core-meta, codegen, testgen 4d7e59e, 18986a0, 9b43de2e

### DIFF
--- a/aas_core3/verification.py
+++ b/aas_core3/verification.py
@@ -122,6 +122,9 @@ class Error:
         self.cause = cause
         self.path = Path()
 
+    def __repr__(self) -> str:
+        return f"Error(path={self.path}, cause={self.cause})"
+
 
 # noinspection SpellCheckingInspection
 def _construct_matches_id_short() -> Pattern[str]:
@@ -2238,15 +2241,12 @@ class _Transformer(aas_types.AbstractTransformer[Iterator[Error]]):
                 (
                     (
                         (that.global_asset_id is not None)
-                        and (that.specific_asset_ids is None)
+                        or (that.specific_asset_ids is not None)
                     )
                 )
-                or (
-                    (
-                        (that.global_asset_id is None)
-                        and (that.specific_asset_ids is not None)
-                        and len(that.specific_asset_ids) >= 1
-                    )
+                and (
+                    not (that.specific_asset_ids is not None)
+                    or (len(that.specific_asset_ids) >= 1)
                 )
             )
         ):
@@ -5676,18 +5676,7 @@ class _Transformer(aas_types.AbstractTransformer[Iterator[Error]]):
     def transform_data_specification_iec_61360(
         self, that: aas_types.DataSpecificationIEC61360
     ) -> Iterator[Error]:
-        if not (
-            (
-                (((that.value is not None) and (that.value_list is None)))
-                or (
-                    (
-                        (that.value is None)
-                        and (that.value_list is not None)
-                        and len(that.value_list.value_reference_pairs) >= 1
-                    )
-                )
-            )
-        ):
+        if not (not (((that.value is not None) and (that.value_list is not None)))):
             yield Error(
                 "Constraint AASc-3a-010: If value is not empty then value "
                 + "list shall be empty and vice versa."

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ pylint==2.15.4
 coverage>=6.5.0,<7
 pyinstaller>=5<6
 twine
-aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@44756fb#egg=aas-core-meta
-aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@607f65c#egg=aas-core-codegen
+aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@4d7e59e#egg=aas-core-meta
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@18986a0#egg=aas-core-codegen

--- a/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/ValueList/valueReferencePairs.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/MinLengthViolation/ValueList/valueReferencePairs.json.errors
@@ -1,2 +1,1 @@
-.asset_administration_shells[0].embedded_data_specifications[0].data_specification_content: Constraint AASc-3a-010: If value is not empty then value list shall be empty and vice versa.
 .asset_administration_shells[0].embedded_data_specifications[0].data_specification_content.value_list: Value reference pair types must contain at least one item.

--- a/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/valueList/valueReferencePairs.xml.errors
+++ b/test_data/Xml/ContainedInEnvironment/Unexpected/MinLengthViolation/valueList/valueReferencePairs.xml.errors
@@ -1,2 +1,1 @@
-.asset_administration_shells[0].embedded_data_specifications[0].data_specification_content: Constraint AASc-3a-010: If value is not empty then value list shall be empty and vice versa.
 .asset_administration_shells[0].embedded_data_specifications[0].data_specification_content.value_list: Value reference pair types must contain at least one item.


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 4d7e59e],
* [aas-core-codegen 18986a0] and
* [aas-core3.0-testgen 9b43de2e].

Notably, this includes two important fixes from aas-core-meta:

* [V3 Fix AASc-3a-010-for-NAND (#281)], and
* [V3 Fix inclusive OR in AASd-131 (#280)].

... and propagates the following minor change from aas-core-codegen:

* [Add `__repr__` to verification errors in Python (#400)].

Fixes #11.

[aas-core-meta 4d7e59e]: https://github.com/aas-core-works/aas-core-meta/commit/4d7e59e
[aas-core-codegen 18986a0]: https://github.com/aas-core-works/aas-core-codegen/commit/18986a0
[aas-core3.0-testgen 9b43de2e]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/9b43de2e
[V3 Fix AASc-3a-010-for-NAND (#281)]: https://github.com/aas-core-works/aas-core-meta/pull/281
[V3 Fix inclusive OR in AASd-131 (#280)]: https://github.com/aas-core-works/aas-core-meta/pull/280
[Add `__repr__` to verification errors in Python (#400)]: https://github.com/aas-core-works/aas-core-codegen/pull/400