### PR TITLE
Release 1.0.0rc3

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate, verify and de/serialize Asset Administration Shells."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.0.0rc2"
+__version__ = "1.0.0rc3"
 __author__ = "Marko Ristin"
 __copyright__ = "2023 Contributors to aas-core3.0-python"
 __license__ = "License :: OSI Approved :: MIT License"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,22 @@
 Change Log
 **********
 
+1.0.0rc3 (2023-09-08)
+=====================
+* Update to aas-core-meta, codegen, testgen 4d7e59e, 18986a0, and
+  9b43de2e (#12)
+
+  In this version, we fix:
+
+  * Constraints AASc-3a-010 and AASd-131, propagated from aas-core-meta
+    pull requests 281 and 280, respectively.
+
+  We also add the following minor feature:
+
+  * Add ```__repr__`` to ```verification.Error`` to facilitate
+    debugging in the downstream clients. Propagated from
+    aas-core-codegen pull request 400.
+
 1.0.0rc2 (2023-06-28)
 =====================
 * Update to aas-core-meta, codegen, testgen 44756fb, 607f65c,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="aas-core3.0",
     # Synchronize with __init__.py and changelog.rst!
-    version="1.0.0rc2",
+    version="1.0.0rc3",
     description="Manipulate, verify and de/serialize Asset Administration Shells.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0-python",


### PR DESCRIPTION
In this version, we fix:

* Constraints AASc-3a-010 and AASd-131, propagated from aas-core-meta pull requests 281 and 280, respectively.

We also add the following minor feature:

* Add ```__repr__`` to ```verification.Error`` to facilitate debugging in the downstream clients. Propagated from aas-core-codegen pull request 400.