### PR TITLE
Release 1.0.1

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate, verify and de/serialize Asset Administration Shells."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __author__ = "Marko Ristin"
 __copyright__ = "2024 Contributors to aas-core3.0-python"
 __license__ = "License :: OSI Approved :: MIT License"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,19 @@
 Change Log
 **********
 
+1.0.1 (2024-02-14)
+==================
+* Test and fix for text attached to end XML elements (#18).
+
+  This patch fixes for the edge case where ElementTree's
+  ```XMLPullParser`` attaches the text to the end element instead of
+  the start element. Previously, some XML files were wrongly reported
+  as incorrect.
+
+  We do not know what causes this different behavior of the parser,
+  but suspect that it has something to do with the size of the parser's
+  buffer.
+
 1.0.0 (2024-02-02)
 ==================
 This is the first stable release. The release candidates stood

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="aas-core3.0",
     # Synchronize with __init__.py and changelog.rst!
-    version="1.0.0",
+    version="1.0.1",
     description="Manipulate, verify and de/serialize Asset Administration Shells.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0-python",


### PR DESCRIPTION
* Test and fix for text attached to end XML elements (#18).

  This patch fixes for the edge case where ElementTree's ```XMLPullParser`` attaches the text to the end element instead of the start element. Previously, some XML files were wrongly reported as incorrect.

  We do not know what causes this different behavior of the parser, but suspect that it has something to do with the size of the parser's buffer.