### PR TITLE
Update to aas-core-meta, codegen, testgen 79314c6, 94399e1, e1087880

### DIFF
--- a/aas_core3/verification.py
+++ b/aas_core3/verification.py
@@ -516,7 +516,7 @@ def _construct_matches_xs_date() -> Pattern[str]:
     month_frag = "((0[1-9])|(1[0-2]))"
     day_frag = f"((0[1-9])|([12]{digit})|(3[01]))"
     minute_frag = f"[0-5]{digit}"
-    timezone_frag = f"(Z|(\\+|-)(0{digit}|1[0-3]):{minute_frag}|14:00)"
+    timezone_frag = f"(Z|(\\+|-)((0{digit}|1[0-3]):{minute_frag}|14:00))"
     date_lexical_rep = f"{year_frag}-{month_frag}-{day_frag}{timezone_frag}?"
     pattern = f"^{date_lexical_rep}$"
 
@@ -549,7 +549,7 @@ def _construct_matches_xs_date_time() -> Pattern[str]:
     minute_frag = f"[0-5]{digit}"
     second_frag = f"([0-5]{digit})(\\.{digit}+)?"
     end_of_day_frag = "24:00:00(\\.0+)?"
-    timezone_frag = f"(Z|(\\+|-)(0{digit}|1[0-3]):{minute_frag}|14:00)"
+    timezone_frag = f"(Z|(\\+|-)((0{digit}|1[0-3]):{minute_frag}|14:00))"
     date_time_lexical_rep = f"{year_frag}-{month_frag}-{day_frag}T(({hour_frag}:{minute_frag}:{second_frag})|{end_of_day_frag}){timezone_frag}?"
     pattern = f"^{date_time_lexical_rep}$"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ pylint==2.15.4
 coverage>=6.5.0,<7
 pyinstaller>=5<6
 twine
-aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@c9692bc#egg=aas-core-meta
-aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@256cc8a#egg=aas-core-codegen
+aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@79314c6#egg=aas-core-meta
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@94399e1#egg=aas-core-codegen

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date/fuzzed_01.json
@@ -8,7 +8,7 @@
       "extensions": [
         {
           "name": "something_aae6caf4",
-          "value": "0705-04-1014:00",
+          "value": "0705-04-10+14:00",
           "valueType": "xs:date"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Date_time/fuzzed_05.json
@@ -8,7 +8,7 @@
       "extensions": [
         {
           "name": "something_aae6caf4",
-          "value": "0532-09-07T18:47:5214:00",
+          "value": "0532-09-07T18:47:52+14:00",
           "valueType": "xs:dateTime"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_06.json
@@ -8,7 +8,7 @@
       "extensions": [
         {
           "name": "something_aae6caf4",
-          "value": "+7626E-86876716",
+          "value": "+76E-86",
           "valueType": "xs:double"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Extension/OverValueExamples/Double/fuzzed_09.json
@@ -8,7 +8,7 @@
       "extensions": [
         {
           "name": "something_aae6caf4",
-          "value": "-.66E-452289",
+          "value": "-.66E-45",
           "valueType": "xs:double"
         }
       ],

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date/fuzzed_01.json
@@ -7,7 +7,7 @@
         {
           "idShort": "something3fdd3eb4",
           "modelType": "Property",
-          "value": "0705-04-1014:00",
+          "value": "0705-04-10+14:00",
           "valueType": "xs:date"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Date_time/fuzzed_05.json
@@ -7,7 +7,7 @@
         {
           "idShort": "something3fdd3eb4",
           "modelType": "Property",
-          "value": "0532-09-07T18:47:5214:00",
+          "value": "0532-09-07T18:47:52+14:00",
           "valueType": "xs:dateTime"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_06.json
@@ -7,7 +7,7 @@
         {
           "idShort": "something3fdd3eb4",
           "modelType": "Property",
-          "value": "+7626E-86876716",
+          "value": "+76E-86",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Property/OverValueExamples/Double/fuzzed_09.json
@@ -7,7 +7,7 @@
         {
           "idShort": "something3fdd3eb4",
           "modelType": "Property",
-          "value": "-.66E-452289",
+          "value": "-.66E-45",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date/fuzzed_01.json
@@ -6,7 +6,7 @@
       "qualifiers": [
         {
           "type": "something_5964ab43",
-          "value": "0705-04-1014:00",
+          "value": "0705-04-10+14:00",
           "valueType": "xs:date"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Date_time/fuzzed_05.json
@@ -6,7 +6,7 @@
       "qualifiers": [
         {
           "type": "something_5964ab43",
-          "value": "0532-09-07T18:47:5214:00",
+          "value": "0532-09-07T18:47:52+14:00",
           "valueType": "xs:dateTime"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_06.json
@@ -6,7 +6,7 @@
       "qualifiers": [
         {
           "type": "something_5964ab43",
-          "value": "+7626E-86876716",
+          "value": "+76E-86",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Qualifier/OverValueExamples/Double/fuzzed_09.json
@@ -6,7 +6,7 @@
       "qualifiers": [
         {
           "type": "something_5964ab43",
-          "value": "-.66E-452289",
+          "value": "-.66E-45",
           "valueType": "xs:double"
         }
       ]

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/fuzzed_01.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date/fuzzed_01.json
@@ -6,8 +6,8 @@
       "submodelElements": [
         {
           "idShort": "something3fdd3eb4",
-          "max": "0705-04-1014:00",
-          "min": "0705-04-1014:00",
+          "max": "0705-04-10+14:00",
+          "min": "0705-04-10+14:00",
           "modelType": "Range",
           "valueType": "xs:date"
         }

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/fuzzed_05.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Date_time/fuzzed_05.json
@@ -6,8 +6,8 @@
       "submodelElements": [
         {
           "idShort": "something3fdd3eb4",
-          "max": "0532-09-07T18:47:5214:00",
-          "min": "0532-09-07T18:47:5214:00",
+          "max": "0532-09-07T18:47:52+14:00",
+          "min": "0532-09-07T18:47:52+14:00",
           "modelType": "Range",
           "valueType": "xs:dateTime"
         }

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_06.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_06.json
@@ -6,8 +6,8 @@
       "submodelElements": [
         {
           "idShort": "something3fdd3eb4",
-          "max": "+7626E-86876716",
-          "min": "+7626E-86876716",
+          "max": "+76E-86",
+          "min": "+76E-86",
           "modelType": "Range",
           "valueType": "xs:double"
         }

--- a/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_09.json
+++ b/test_data/Json/ContainedInEnvironment/Expected/Range/OverMinMaxExamples/Double/fuzzed_09.json
@@ -6,8 +6,8 @@
       "submodelElements": [
         {
           "idShort": "something3fdd3eb4",
-          "max": "-.66E-452289",
-          "min": "-.66E-452289",
+          "max": "-.66E-45",
+          "min": "-.66E-45",
           "modelType": "Range",
           "valueType": "xs:double"
         }

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/fuzzed_01.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date/fuzzed_01.xml
@@ -5,7 +5,7 @@
 				<extension>
 					<name>something_aae6caf4</name>
 					<valueType>xs:date</valueType>
-					<value>0705-04-1014:00</value>
+					<value>0705-04-10+14:00</value>
 				</extension>
 			</extensions>
 			<id>something_142922d6</id>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/fuzzed_05.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Date_time/fuzzed_05.xml
@@ -5,7 +5,7 @@
 				<extension>
 					<name>something_aae6caf4</name>
 					<valueType>xs:dateTime</valueType>
-					<value>0532-09-07T18:47:5214:00</value>
+					<value>0532-09-07T18:47:52+14:00</value>
 				</extension>
 			</extensions>
 			<id>something_142922d6</id>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Double/fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Double/fuzzed_06.xml
@@ -5,7 +5,7 @@
 				<extension>
 					<name>something_aae6caf4</name>
 					<valueType>xs:double</valueType>
-					<value>+7626E-86876716</value>
+					<value>+76E-86</value>
 				</extension>
 			</extensions>
 			<id>something_142922d6</id>

--- a/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Double/fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/extension/OverValueExamples/Double/fuzzed_09.xml
@@ -5,7 +5,7 @@
 				<extension>
 					<name>something_aae6caf4</name>
 					<valueType>xs:double</valueType>
-					<value>-.66E-452289</value>
+					<value>-.66E-45</value>
 				</extension>
 			</extensions>
 			<id>something_142922d6</id>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/fuzzed_01.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date/fuzzed_01.xml
@@ -6,7 +6,7 @@
 				<property>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:date</valueType>
-					<value>0705-04-1014:00</value>
+					<value>0705-04-10+14:00</value>
 				</property>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/fuzzed_05.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Date_time/fuzzed_05.xml
@@ -6,7 +6,7 @@
 				<property>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:dateTime</valueType>
-					<value>0532-09-07T18:47:5214:00</value>
+					<value>0532-09-07T18:47:52+14:00</value>
 				</property>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Double/fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Double/fuzzed_06.xml
@@ -6,7 +6,7 @@
 				<property>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:double</valueType>
-					<value>+7626E-86876716</value>
+					<value>+76E-86</value>
 				</property>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Double/fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/property/OverValueExamples/Double/fuzzed_09.xml
@@ -6,7 +6,7 @@
 				<property>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:double</valueType>
-					<value>-.66E-452289</value>
+					<value>-.66E-45</value>
 				</property>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/fuzzed_01.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date/fuzzed_01.xml
@@ -6,7 +6,7 @@
 				<qualifier>
 					<type>something_5964ab43</type>
 					<valueType>xs:date</valueType>
-					<value>0705-04-1014:00</value>
+					<value>0705-04-10+14:00</value>
 				</qualifier>
 			</qualifiers>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/fuzzed_05.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Date_time/fuzzed_05.xml
@@ -6,7 +6,7 @@
 				<qualifier>
 					<type>something_5964ab43</type>
 					<valueType>xs:dateTime</valueType>
-					<value>0532-09-07T18:47:5214:00</value>
+					<value>0532-09-07T18:47:52+14:00</value>
 				</qualifier>
 			</qualifiers>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Double/fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Double/fuzzed_06.xml
@@ -6,7 +6,7 @@
 				<qualifier>
 					<type>something_5964ab43</type>
 					<valueType>xs:double</valueType>
-					<value>+7626E-86876716</value>
+					<value>+76E-86</value>
 				</qualifier>
 			</qualifiers>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Double/fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/qualifier/OverValueExamples/Double/fuzzed_09.xml
@@ -6,7 +6,7 @@
 				<qualifier>
 					<type>something_5964ab43</type>
 					<valueType>xs:double</valueType>
-					<value>-.66E-452289</value>
+					<value>-.66E-45</value>
 				</qualifier>
 			</qualifiers>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/fuzzed_01.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date/fuzzed_01.xml
@@ -6,8 +6,8 @@
 				<range>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:date</valueType>
-					<min>0705-04-1014:00</min>
-					<max>0705-04-1014:00</max>
+					<min>0705-04-10+14:00</min>
+					<max>0705-04-10+14:00</max>
 				</range>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/fuzzed_05.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Date_time/fuzzed_05.xml
@@ -6,8 +6,8 @@
 				<range>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:dateTime</valueType>
-					<min>0532-09-07T18:47:5214:00</min>
-					<max>0532-09-07T18:47:5214:00</max>
+					<min>0532-09-07T18:47:52+14:00</min>
+					<max>0532-09-07T18:47:52+14:00</max>
 				</range>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Double/fuzzed_06.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Double/fuzzed_06.xml
@@ -6,8 +6,8 @@
 				<range>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:double</valueType>
-					<min>+7626E-86876716</min>
-					<max>+7626E-86876716</max>
+					<min>+76E-86</min>
+					<max>+76E-86</max>
 				</range>
 			</submodelElements>
 		</submodel>

--- a/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Double/fuzzed_09.xml
+++ b/test_data/Xml/ContainedInEnvironment/Expected/range/OverMinMaxExamples/Double/fuzzed_09.xml
@@ -6,8 +6,8 @@
 				<range>
 					<idShort>something3fdd3eb4</idShort>
 					<valueType>xs:double</valueType>
-					<min>-.66E-452289</min>
-					<max>-.66E-452289</max>
+					<min>-.66E-45</min>
+					<max>-.66E-45</max>
 				</range>
 			</submodelElements>
 		</submodel>


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta 79314c6],
* [aas-core-codegen 94399e1] and
* [aas-core3.0-testgen e1087880].

Notably, we fix the patterns for date and date-times with zone offset `14:00` which previously allowed for a concatenation without a plus sign.

In addition, we fix the test data for defects which were detected while testing with the generated C++ SDK. This concerns the examples of doubles which overflowed in C++, but where silently accepted otherwise.

[aas-core-meta 79314c6]: https://github.com/aas-core-works/aas-core-meta/commit/79314c6
[aas-core-codegen 94399e1]: https://github.com/aas-core-works/aas-core-codegen/commit/94399e1
[aas-core3.0-testgen e1087880]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/e1087880