### PR TITLE
Release 1.0.2

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate, verify and de/serialize Asset Administration Shells."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __author__ = "Marko Ristin"
 __copyright__ = "2024 Contributors to aas-core3.0-python"
 __license__ = "License :: OSI Approved :: MIT License"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,14 @@
 Change Log
 **********
 
+1.0.2 (2024-03-13)
+==================
+* Update to aas-core-meta, codegen, testgen 79314c6, 94399e1, e1087880 (#20)
+
+  This patch release brings about the fix for patterns concerning dates and
+  date-times with zone offset `14:00` which previously allowed for
+  a concatenation without a plus sign.
+
 1.0.1 (2024-02-14)
 ==================
 * Test and fix for text attached to end XML elements (#18).

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="aas-core3.0",
     # Synchronize with __init__.py and changelog.rst!
-    version="1.0.1",
+    version="1.0.2",
     description="Manipulate, verify and de/serialize Asset Administration Shells.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0-python",


### PR DESCRIPTION
* Update to aas-core-meta, codegen, testgen 79314c6, 94399e1, e1087880 (#20)

  This patch release brings about the fix for patterns concerning dates and date-times with zone offset `14:00` which previously allowed for a concatenation without a plus sign.