### PR TITLE
Release 1.0.3

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate, verify and de/serialize Asset Administration Shells."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 __author__ = "Marko Ristin"
 __copyright__ = "2024 Contributors to aas-core3.0-python"
 __license__ = "License :: OSI Approved :: MIT License"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,13 @@
 Change Log
 **********
 
+1.0.3 (2024-03-22)
+==================
+* Update to aas-core-meta, codegen, testgen cb28d18, c414f32, 6ff39c260 (#23)
+
+  We propagate the fix from abnf-to-regex related to maximum qualifiers
+  which had been mistakenly represented as exact repetition before.
+
 1.0.2 (2024-03-13)
 ==================
 * Update to aas-core-meta, codegen, testgen 79314c6, 94399e1, e1087880 (#20)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="aas-core3.0",
     # Synchronize with __init__.py and changelog.rst!
-    version="1.0.2",
+    version="1.0.3",
     description="Manipulate, verify and de/serialize Asset Administration Shells.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0-python",


### PR DESCRIPTION
* Update to aas-core-meta, codegen, testgen cb28d18, c414f32, 6ff39c260 (#23)

  We propagate the fix from abnf-to-regex related to maximum qualifiers which had been mistakenly represented as exact repetition before.