### PR TITLE
Fix readthedocs config for missing `os`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py
@@ -15,7 +21,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.8
    install:
    - method: pip
      path: .


### PR DESCRIPTION
We received the error:

```
Config validation error in build.os. Value build not found.
```

This patch fixes the error by specifying the `build.os` as written in the example linked from the [readthedocs issue 11173].

[readthedocs issue 11173]: https://github.com/readthedocs/readthedocs.org/issues/11173