### PR TITLE
Fix jsonization confusing ``dict`` for array

### DIFF
--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/NullViolation/DataSpecificationIec61360/preferredName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/NullViolation/DataSpecificationIec61360/preferredName.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.preferredName: Expected an iterable, but got: <class 'NoneType'>
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.preferredName: Expected something array-like, but got: <class 'NoneType'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/NullViolation/Reference/keys.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/NullViolation/Reference/keys.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].derivedFrom.keys: Expected an iterable, but got: <class 'NoneType'>
+assetAdministrationShells[0].derivedFrom.keys: Expected something array-like, but got: <class 'NoneType'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/NullViolation/ValueList/valueReferencePairs.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/NullViolation/ValueList/valueReferencePairs.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList.valueReferencePairs: Expected an iterable, but got: <class 'NoneType'>
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList.valueReferencePairs: Expected something array-like, but got: <class 'NoneType'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AdministrativeInformation/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AdministrativeInformation/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].administration.embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].administration.embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/annotations.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/annotations.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].annotations[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].annotations: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AnnotatedRelationshipElement/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/description.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].description[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/displayName.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/extensions.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/submodels.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/AssetAdministrationShell/submodels.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].submodels[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].submodels: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/BasicEventElement/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Blob/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Capability/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/description.json.exception
@@ -1,1 +1,1 @@
-conceptDescriptions[0].description[0]: Expected a mapping, but got: <class 'str'>
+conceptDescriptions[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/displayName.json.exception
@@ -1,1 +1,1 @@
-conceptDescriptions[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+conceptDescriptions[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-conceptDescriptions[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+conceptDescriptions[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/extensions.json.exception
@@ -1,1 +1,1 @@
-conceptDescriptions[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+conceptDescriptions[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/isCaseOf.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ConceptDescription/isCaseOf.json.exception
@@ -1,1 +1,1 @@
-conceptDescriptions[0].isCaseOf[0]: Expected a mapping, but got: <class 'str'>
+conceptDescriptions[0].isCaseOf: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/definition.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/definition.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.definition[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.definition: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/preferredName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/preferredName.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.preferredName[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.preferredName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/shortName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/DataSpecificationIec61360/shortName.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.shortName[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.shortName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/statements.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/statements.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].statements[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].statements: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Entity/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Extension/refersTo.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Extension/refersTo.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].extensions[0].refersTo[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].extensions[0].refersTo: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Extension/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Extension/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].extensions[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].extensions[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/File/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/value.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/MultiLanguageProperty/value.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].value[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].value: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/inoutputVariables.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/inoutputVariables.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].inoutputVariables[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].inoutputVariables: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/inputVariables.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/inputVariables.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].inputVariables[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].inputVariables: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/outputVariables.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/outputVariables.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].outputVariables[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].outputVariables: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Operation/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Property/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Qualifier/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Qualifier/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].qualifiers[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].qualifiers[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Range/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Reference/keys.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Reference/keys.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].derivedFrom.keys[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].derivedFrom.keys: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ReferenceElement/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/RelationshipElement/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SpecificAssetId/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SpecificAssetId/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].assetInformation.specificAssetIds[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].assetInformation.specificAssetIds[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/submodelElements.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/submodelElements.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/Submodel/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/value.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementCollection/value.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].value[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].value: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/description.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/description.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].description[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].description: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/displayName.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/displayName.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].displayName[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].displayName: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/embeddedDataSpecifications.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/embeddedDataSpecifications.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].embeddedDataSpecifications[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].embeddedDataSpecifications: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/extensions.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/extensions.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].extensions[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].extensions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/qualifiers.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/qualifiers.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].qualifiers[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].qualifiers: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/supplementalSemanticIds.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/supplementalSemanticIds.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].supplementalSemanticIds[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].supplementalSemanticIds: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/value.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/SubmodelElementList/value.json.exception
@@ -1,1 +1,1 @@
-submodels[0].submodelElements[0].value[0]: Expected a mapping, but got: <class 'str'>
+submodels[0].submodelElements[0].value: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ValueList/valueReferencePairs.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/TypeViolation/ValueList/valueReferencePairs.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList.valueReferencePairs[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent.valueList.valueReferencePairs: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/SelfContained/Unexpected/Unserializable/TypeViolation/Environment/assetAdministrationShells.json.exception
+++ b/test_data/Json/SelfContained/Unexpected/Unserializable/TypeViolation/Environment/assetAdministrationShells.json.exception
@@ -1,1 +1,1 @@
-assetAdministrationShells[0]: Expected a mapping, but got: <class 'str'>
+assetAdministrationShells: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/SelfContained/Unexpected/Unserializable/TypeViolation/Environment/conceptDescriptions.json.exception
+++ b/test_data/Json/SelfContained/Unexpected/Unserializable/TypeViolation/Environment/conceptDescriptions.json.exception
@@ -1,1 +1,1 @@
-conceptDescriptions[0]: Expected a mapping, but got: <class 'str'>
+conceptDescriptions: Expected something array-like, but got: <class 'str'>

--- a/test_data/Json/SelfContained/Unexpected/Unserializable/TypeViolation/Environment/submodels.json.exception
+++ b/test_data/Json/SelfContained/Unexpected/Unserializable/TypeViolation/Environment/submodels.json.exception
@@ -1,1 +1,1 @@
-submodels[0]: Expected a mapping, but got: <class 'str'>
+submodels: Expected something array-like, but got: <class 'str'>

--- a/tests/test_jsonization_and_is_array_like.py
+++ b/tests/test_jsonization_and_is_array_like.py
@@ -1,0 +1,34 @@
+# pylint: disable=missing-docstring
+
+# NOTE (mristin):
+# We explicitly check that dictionaries are not mistaken for array-like objects during
+# the de-serialization.
+#
+# This is a regression test for the following issue:
+# https://github.com/aas-core-works/aas-core3.0-python/issues/31
+
+import unittest
+from typing import Optional
+
+import aas_core3.jsonization as aasjsonization
+
+
+class TestIsArrayLike(unittest.TestCase):
+    def test_example(self) -> None:
+        jsonable = {"submodels": {}}  # type: aasjsonization.Jsonable
+
+        got_exception = None  # type: Optional[aasjsonization.DeserializationException]
+
+        try:
+            _ = aasjsonization.environment_from_jsonable(jsonable)
+        except aasjsonization.DeserializationException as exception:
+            got_exception = exception
+
+        assert got_exception is not None
+        self.assertEqual(
+            "Expected something array-like, but got: <class 'dict'>", str(got_exception)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We fix the JSON de-serialization so that it explicitly check that a property is an array-like value instead of simply checking for inheritance from ``collections.abc.Iterable``, as mappings are also iterables in Python.

This corresponds to [aas-core-codegen bcab1a9c].

[aas-core-codegen bcab1a9c]: https://github.com/aas-core-works/aas-core-codegen/commit/bcab1a9c

Fixes #31.