### PR TITLE
Fix ``requirements-dev.txt`` for stricter parsing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ black==22.10.0
 mypy==0.982
 pylint==2.15.4
 coverage>=6.5.0,<7
-pyinstaller>=5<6
+pyinstaller>=5,<6
 twine
 aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@6d5411b#egg=aas-core-meta
 aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@d06db62b#egg=aas-core-codegen


### PR DESCRIPTION
We forgot a comma in one of the dependencies which caused Python to eventually complain in later versions of Python 3.10.