### PR TITLE
Check explicitly for missing model type

### DIFF
--- a/aas_core3/jsonization.py
+++ b/aas_core3/jsonization.py
@@ -1114,6 +1114,11 @@ def asset_administration_shell_from_jsonable(
 
     setter = _SetterForAssetAdministrationShell()
 
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_ASSET_ADMINISTRATION_SHELL.get(key)
         if setter_method is None:
@@ -1708,6 +1713,11 @@ def submodel_from_jsonable(jsonable: Jsonable) -> aas_types.Submodel:
         raise DeserializationException(f"Expected a mapping, but got: {type(jsonable)}")
 
     setter = _SetterForSubmodel()
+
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_SUBMODEL.get(key)
@@ -2364,6 +2374,11 @@ def submodel_element_list_from_jsonable(
 
     setter = _SetterForSubmodelElementList()
 
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_SUBMODEL_ELEMENT_LIST.get(key)
         if setter_method is None:
@@ -2630,6 +2645,11 @@ def submodel_element_collection_from_jsonable(
         raise DeserializationException(f"Expected a mapping, but got: {type(jsonable)}")
 
     setter = _SetterForSubmodelElementCollection()
+
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_SUBMODEL_ELEMENT_COLLECTION.get(key)
@@ -2921,6 +2941,11 @@ def property_from_jsonable(jsonable: Jsonable) -> aas_types.Property:
 
     setter = _SetterForProperty()
 
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_PROPERTY.get(key)
         if setter_method is None:
@@ -3193,6 +3218,11 @@ def multi_language_property_from_jsonable(
 
     setter = _SetterForMultiLanguageProperty()
 
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_MULTI_LANGUAGE_PROPERTY.get(key)
         if setter_method is None:
@@ -3452,6 +3482,11 @@ def range_from_jsonable(jsonable: Jsonable) -> aas_types.Range:
 
     setter = _SetterForRange()
 
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_RANGE.get(key)
         if setter_method is None:
@@ -3696,6 +3731,11 @@ def reference_element_from_jsonable(jsonable: Jsonable) -> aas_types.ReferenceEl
         raise DeserializationException(f"Expected a mapping, but got: {type(jsonable)}")
 
     setter = _SetterForReferenceElement()
+
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_REFERENCE_ELEMENT.get(key)
@@ -3945,6 +3985,11 @@ def blob_from_jsonable(jsonable: Jsonable) -> aas_types.Blob:
         raise DeserializationException(f"Expected a mapping, but got: {type(jsonable)}")
 
     setter = _SetterForBlob()
+
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_BLOB.get(key)
@@ -4198,6 +4243,11 @@ def file_from_jsonable(jsonable: Jsonable) -> aas_types.File:
         raise DeserializationException(f"Expected a mapping, but got: {type(jsonable)}")
 
     setter = _SetterForFile()
+
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_FILE.get(key)
@@ -4478,6 +4528,11 @@ def annotated_relationship_element_from_jsonable(
         raise DeserializationException(f"Expected a mapping, but got: {type(jsonable)}")
 
     setter = _SetterForAnnotatedRelationshipElement()
+
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_ANNOTATED_RELATIONSHIP_ELEMENT.get(key)
@@ -4785,6 +4840,11 @@ def entity_from_jsonable(jsonable: Jsonable) -> aas_types.Entity:
         raise DeserializationException(f"Expected a mapping, but got: {type(jsonable)}")
 
     setter = _SetterForEntity()
+
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_ENTITY.get(key)
@@ -5326,6 +5386,11 @@ def basic_event_element_from_jsonable(
 
     setter = _SetterForBasicEventElement()
 
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_BASIC_EVENT_ELEMENT.get(key)
         if setter_method is None:
@@ -5648,6 +5713,11 @@ def operation_from_jsonable(jsonable: Jsonable) -> aas_types.Operation:
 
     setter = _SetterForOperation()
 
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_OPERATION.get(key)
         if setter_method is None:
@@ -5932,6 +6002,11 @@ def capability_from_jsonable(jsonable: Jsonable) -> aas_types.Capability:
 
     setter = _SetterForCapability()
 
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
+
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_CAPABILITY.get(key)
         if setter_method is None:
@@ -6147,6 +6222,11 @@ def concept_description_from_jsonable(
         raise DeserializationException(f"Expected a mapping, but got: {type(jsonable)}")
 
     setter = _SetterForConceptDescription()
+
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_CONCEPT_DESCRIPTION.get(key)
@@ -7414,6 +7494,11 @@ def data_specification_iec_61360_from_jsonable(
         raise DeserializationException(f"Expected a mapping, but got: {type(jsonable)}")
 
     setter = _SetterForDataSpecificationIEC61360()
+
+    if "modelType" not in jsonable:
+        raise DeserializationException(
+            "Expected the property modelType, but found none"
+        )
 
     for key, jsonable_value in jsonable.items():
         setter_method = _SETTER_MAP_FOR_DATA_SPECIFICATION_IEC_61360.get(key)

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AnnotatedRelationshipElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json
@@ -1,0 +1,11 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "id": "something_142922d6"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/AssetAdministrationShell/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+assetAdministrationShells[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json
@@ -1,0 +1,24 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "output",
+          "idShort": "something3fdd3eb4",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "urn:another-example11:3679ef43"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "off"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/BasicEventElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Blob/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Capability/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json
@@ -1,0 +1,7 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_8ccad77f"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ConceptDescription/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+conceptDescriptions[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json
@@ -1,0 +1,29 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecificationContent": {
+            "preferredName": [
+              {
+                "language": "i-enochian",
+                "text": "something_84b0b440"
+              },
+              {
+                "language": "en-GB",
+                "text": "Something random in English 5b15c20d"
+              }
+            ],
+            "value": "something_13759f45"
+          }
+        }
+      ],
+      "id": "something_142922d6",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/DataSpecificationIec61360/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "CoManagedEntity",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Entity/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/File/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/MultiLanguageProperty/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Operation/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Property/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Range/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/ReferenceElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json
@@ -1,0 +1,31 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/RelationshipElement/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json
@@ -1,0 +1,7 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/Submodel/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json
@@ -1,0 +1,13 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementCollection/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "typeValueListElement": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/MissingModelType/SubmodelElementList/withoutModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Expected the property modelType, but found none


### PR DESCRIPTION
We add an explicit check for missing ``modelType`` to account for the case where a concrete class without descendants needs a model type for backwards compatibility even though the model type property is redundant.

The code corresponds to [aas-core-codegen 84ccbb64], and the test data correspods to [aas-core3.0-testgen 1b00dbe45].

[aas-core-codegen 84ccbb64]: https://github.com/aas-core-works/aas-core-codegen/commit/84ccbb64
[aas-core3.0-testgen 1b00dbe45]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/1b00dbe45

Fixes #32.