### PR TITLE
Check explicitly for invalid model types

### DIFF
--- a/aas_core3/jsonization.py
+++ b/aas_core3/jsonization.py
@@ -1114,9 +1114,16 @@ def asset_administration_shell_from_jsonable(
 
     setter = _SetterForAssetAdministrationShell()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "AssetAdministrationShell":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'AssetAdministrationShell', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -1714,9 +1721,15 @@ def submodel_from_jsonable(jsonable: Jsonable) -> aas_types.Submodel:
 
     setter = _SetterForSubmodel()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "Submodel":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Submodel', " f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -2374,9 +2387,16 @@ def submodel_element_list_from_jsonable(
 
     setter = _SetterForSubmodelElementList()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "SubmodelElementList":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'SubmodelElementList', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -2646,9 +2666,16 @@ def submodel_element_collection_from_jsonable(
 
     setter = _SetterForSubmodelElementCollection()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "SubmodelElementCollection":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'SubmodelElementCollection', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -2941,9 +2968,15 @@ def property_from_jsonable(jsonable: Jsonable) -> aas_types.Property:
 
     setter = _SetterForProperty()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "Property":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Property', " f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -3218,9 +3251,16 @@ def multi_language_property_from_jsonable(
 
     setter = _SetterForMultiLanguageProperty()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "MultiLanguageProperty":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'MultiLanguageProperty', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -3482,9 +3522,15 @@ def range_from_jsonable(jsonable: Jsonable) -> aas_types.Range:
 
     setter = _SetterForRange()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "Range":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Range', " f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -3732,9 +3778,16 @@ def reference_element_from_jsonable(jsonable: Jsonable) -> aas_types.ReferenceEl
 
     setter = _SetterForReferenceElement()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "ReferenceElement":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'ReferenceElement', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -3986,9 +4039,15 @@ def blob_from_jsonable(jsonable: Jsonable) -> aas_types.Blob:
 
     setter = _SetterForBlob()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "Blob":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Blob', " f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -4244,9 +4303,15 @@ def file_from_jsonable(jsonable: Jsonable) -> aas_types.File:
 
     setter = _SetterForFile()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "File":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'File', " f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -4529,9 +4594,16 @@ def annotated_relationship_element_from_jsonable(
 
     setter = _SetterForAnnotatedRelationshipElement()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "AnnotatedRelationshipElement":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'AnnotatedRelationshipElement', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -4841,9 +4913,15 @@ def entity_from_jsonable(jsonable: Jsonable) -> aas_types.Entity:
 
     setter = _SetterForEntity()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "Entity":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Entity', " f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -5386,9 +5464,16 @@ def basic_event_element_from_jsonable(
 
     setter = _SetterForBasicEventElement()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "BasicEventElement":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'BasicEventElement', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -5713,9 +5798,15 @@ def operation_from_jsonable(jsonable: Jsonable) -> aas_types.Operation:
 
     setter = _SetterForOperation()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "Operation":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Operation', " f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -6002,9 +6093,15 @@ def capability_from_jsonable(jsonable: Jsonable) -> aas_types.Capability:
 
     setter = _SetterForCapability()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "Capability":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'Capability', " f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -6223,9 +6320,16 @@ def concept_description_from_jsonable(
 
     setter = _SetterForConceptDescription()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "ConceptDescription":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'ConceptDescription', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():
@@ -7495,9 +7599,16 @@ def data_specification_iec_61360_from_jsonable(
 
     setter = _SetterForDataSpecificationIEC61360()
 
-    if "modelType" not in jsonable:
+    model_type = jsonable.get("modelType", None)
+    if model_type is None:
         raise DeserializationException(
             "Expected the property modelType, but found none"
+        )
+
+    if model_type != "DataSpecificationIec61360":
+        raise DeserializationException(
+            f"Invalid modelType, expected 'DataSpecificationIec61360', "
+            f"but got: {model_type!r}"
         )
 
     for key, jsonable_value in jsonable.items():

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json
@@ -1,0 +1,32 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AnnotatedRelationshipElement/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json
@@ -1,0 +1,12 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "id": "something_142922d6",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/AssetAdministrationShell/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+assetAdministrationShells[0]: Invalid modelType, expected 'AssetAdministrationShell', but got: 'aCompletelyInvalidModelType'

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json
@@ -1,0 +1,25 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "direction": "output",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "observed": {
+            "keys": [
+              {
+                "type": "Submodel",
+                "value": "urn:another-example11:3679ef43"
+              }
+            ],
+            "type": "ModelReference"
+          },
+          "state": "off"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/BasicEventElement/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Blob/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Capability/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json
@@ -1,0 +1,8 @@
+{
+  "conceptDescriptions": [
+    {
+      "id": "something_8ccad77f",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ConceptDescription/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+conceptDescriptions[0]: Invalid modelType, expected 'ConceptDescription', but got: 'aCompletelyInvalidModelType'

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json
@@ -1,0 +1,30 @@
+{
+  "assetAdministrationShells": [
+    {
+      "assetInformation": {
+        "assetKind": "NotApplicable",
+        "globalAssetId": "something_eea66fa1"
+      },
+      "embeddedDataSpecifications": [
+        {
+          "dataSpecificationContent": {
+            "modelType": "aCompletelyInvalidModelType",
+            "preferredName": [
+              {
+                "language": "i-enochian",
+                "text": "something_84b0b440"
+              },
+              {
+                "language": "en-GB",
+                "text": "Something random in English 5b15c20d"
+              }
+            ],
+            "value": "something_13759f45"
+          }
+        }
+      ],
+      "id": "something_142922d6",
+      "modelType": "AssetAdministrationShell"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/DataSpecificationIec61360/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+assetAdministrationShells[0].embeddedDataSpecifications[0].dataSpecificationContent: Unexpected model type for DataSpecificationContent: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "entityType": "CoManagedEntity",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Entity/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "contentType": "'VbrwFrYTU/fO7NnLxq   \t; \tMX.`10dB732`X5yRy=I56Ov9Us\t ;\t\t pRb~~hdw_C%2Zf=\"\"\t\t\t    \t\t\t \t \t\t \t  ; h=1t",
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/File/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/MultiLanguageProperty/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Operation/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Property/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "valueType": "xs:decimal"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Range/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/ReferenceElement/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json
@@ -1,0 +1,32 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "first": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:another-company01:f390f801"
+              }
+            ],
+            "type": "ExternalReference"
+          },
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "second": {
+            "keys": [
+              {
+                "type": "GlobalReference",
+                "value": "urn:an-example05:b7bf2725"
+              }
+            ],
+            "type": "ExternalReference"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/RelationshipElement/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json
@@ -1,0 +1,8 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "aCompletelyInvalidModelType"
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/Submodel/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0]: Invalid modelType, expected 'Submodel', but got: 'aCompletelyInvalidModelType'

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json
@@ -1,0 +1,14 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementCollection/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json
@@ -1,0 +1,15 @@
+{
+  "submodels": [
+    {
+      "id": "something_48c66017",
+      "modelType": "Submodel",
+      "submodelElements": [
+        {
+          "idShort": "something3fdd3eb4",
+          "modelType": "aCompletelyInvalidModelType",
+          "typeValueListElement": "Entity"
+        }
+      ]
+    }
+  ]
+}

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json.exception
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Unserializable/InvalidModelType/SubmodelElementList/invalidModelType.json.exception
@@ -1,0 +1,1 @@
+submodels[0].submodelElements[0]: Unexpected model type for SubmodelElement: aCompletelyInvalidModelType


### PR DESCRIPTION
We explicitly check during the JSON de-serialization that model types correspond to the expected model types. We need to be particularly careful with concrete classes without descendants with a mandatory ``modelType``, as they do not necessarily require a model type for de-serialization, but the specs mandate it for reasons of backward compatibility.

The code corresponds to [aas-core-codegen cd92d208], and the test data corresponds to [aas-core3.0-testgen 9e523511c].

This is related to the issue #32, which discovered the problematic in the first place.

[aas-core-codegen cd92d208]: https://github.com/aas-core-works/aas-core-codegen/commit/cd92d208
[aas-core3.0-testgen 9e523511c]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/9e523511c