### PR TITLE
Replace test data first in the update script

### DIFF
--- a/dev_scripts/update_to_aas_core_meta_codegen_and_testgen.py
+++ b/dev_scripts/update_to_aas_core_meta_codegen_and_testgen.py
@@ -599,11 +599,11 @@ def main() -> int:
         aas_core_codegen_repo=aas_core_codegen_repo, our_repo=our_repo
     )
 
+    _replace_test_data(our_repo=our_repo, aas_core_testgen_repo=aas_core_testgen_repo)
+
     exit_code = _generate_test_code(our_repo=our_repo)
     if exit_code is not None:
         return exit_code
-
-    _replace_test_data(our_repo=our_repo, aas_core_testgen_repo=aas_core_testgen_repo)
 
     _reformat_code(our_repo=our_repo)
 


### PR DESCRIPTION
We need to replace the test data first on breaking changes in specification since the test code generation already runs a couple of preliminary consistency checks against the test data.