### PR TITLE
Update to aas-core-meta, codegen, testgen bd56058, a25c6436, 839836181

### DIFF
--- a/aas_core3/verification.py
+++ b/aas_core3/verification.py
@@ -2874,7 +2874,7 @@ class _Transformer(aas_types.AbstractTransformer[Iterator[Error]]):
         if not (
             not (
                 (
-                    (that.value is not None)
+                    (that.type_value_list_element is not None)
                     and (
                         (
                             that.type_value_list_element
@@ -2888,8 +2888,13 @@ class _Transformer(aas_types.AbstractTransformer[Iterator[Error]]):
             or (
                 (
                     (that.value_type_list_element is not None)
-                    and properties_or_ranges_have_value_type(
-                        that.value, that.value_type_list_element
+                    and (
+                        (
+                            (that.value is None)
+                            or properties_or_ranges_have_value_type(
+                                that.value, that.value_type_list_element
+                            )
+                        )
                     )
                 )
             )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ pylint==2.15.4
 coverage>=6.5.0,<7
 pyinstaller>=5,<6
 twine
-aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@31d6afd#egg=aas-core-meta
-aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@0f7345e1#egg=aas-core-codegen
+aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@bd56058#egg=aas-core-meta
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a25c6436#egg=aas-core-codegen


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta bd56058],
* [aas-core-codegen a25c6436] and
* [aas-core3.0-testgen 839836181].

Notably, we propagate the fix for AASd-109 where we change the invariant such that it checks for the consistency among properties even when a ``value`` property is missing.

[aas-core-meta bd56058]: https://github.com/aas-core-works/aas-core-meta/commit/bd56058
[aas-core-codegen a25c6436]: https://github.com/aas-core-works/aas-core-codegen/commit/a25c6436
[aas-core3.0-testgen 839836181]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/839836181