### PR TITLE
Update to aas-core-meta, codegen, testgen f9cbdb3, 6df5c9e8, 5a705a0b1

### DIFF
--- a/aas_core3/verification.py
+++ b/aas_core3/verification.py
@@ -2874,15 +2874,10 @@ class _Transformer(aas_types.AbstractTransformer[Iterator[Error]]):
         if not (
             not (
                 (
-                    (that.type_value_list_element is not None)
-                    and (
-                        (
-                            that.type_value_list_element
-                            == aas_types.AASSubmodelElements.PROPERTY
-                            or that.type_value_list_element
-                            == aas_types.AASSubmodelElements.RANGE
-                        )
-                    )
+                    that.type_value_list_element
+                    == aas_types.AASSubmodelElements.PROPERTY
+                    or that.type_value_list_element
+                    == aas_types.AASSubmodelElements.RANGE
                 )
             )
             or (

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ pylint==2.15.4
 coverage>=6.5.0,<7
 pyinstaller>=5,<6
 twine
-aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@bd56058#egg=aas-core-meta
-aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@a25c6436#egg=aas-core-codegen
+aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@f9cbdb3#egg=aas-core-meta
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@6df5c9e8#egg=aas-core-codegen


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta f9cbdb3],
* [aas-core-codegen 6df5c9e8] and
* [aas-core3.0-testgen 5a705a0b1].

Notably, we propagate the fix from aas-core-meta. We fix the invariant AASd-109 for type inference as we erroneously included a non-nullness check for a non-optional attribute (``type_value_list_element``).

[aas-core-meta f9cbdb3]: https://github.com/aas-core-works/aas-core-meta/commit/f9cbdb3
[aas-core-codegen 6df5c9e8]: https://github.com/aas-core-works/aas-core-codegen/commit/6df5c9e8
[aas-core3.0-testgen 5a705a0b1]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/5a705a0b1