### PR TITLE
Test and explain how to handle XML attributes

### DIFF
--- a/docs/how-to-build-docs.md
+++ b/docs/how-to-build-docs.md
@@ -28,5 +28,5 @@ The documentation is in the `docs/build` directory.
 Test the examples in the documentation with the ``doctest`` builder:
 
 ```
-sphinx-build source -b doctest
+sphinx-build source build -b doctest
 ```


### PR DESCRIPTION
We add a test to verify that XML attributes can be erased during the de-serialization to avoid de-serialization errors.

In addition, we adapt the test code and add it to documentation for visibility.

Fixes #44.