### PR TITLE
Release 1.1.1

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate, verify and de/serialize Asset Administration Shells."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __author__ = "Marko Ristin"
 __copyright__ = "2024 Contributors to aas-core3.0-python"
 __license__ = "License :: OSI Approved :: MIT License"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,13 @@
 Change Log
 **********
 
+1.1.1 (2024-11-06)
+==================
+We propagate the fix for V3.0 in the meta-model which reverted
+the order of ``data_specification`` and ``data_specification_content``.
+This was necessary so that the XML schemas for V3.0 remain backwards
+compatible.
+
 1.1.0 (2024-10-27)
 ==================
 We introduce additional functions which can de-serialize all model

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="aas-core3.0",
     # Synchronize with __init__.py and changelog.rst!
-    version="1.1.0",
+    version="1.1.1",
     description="Manipulate, verify and de/serialize Asset Administration Shells.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0-python",


### PR DESCRIPTION
We propagate the fix for V3.0 in the meta-model which reverted the order of ``data_specification`` and ``data_specification_content``. This was necessary so that the XML schemas for V3.0 remain backwards compatible.