### PR TITLE
Update to aas-core-meta, codegen, testgen f2fd738, c77b7dc6, a8c4155e4

### DIFF
--- a/aas_core3/verification.py
+++ b/aas_core3/verification.py
@@ -5808,6 +5808,16 @@ def verify(that: aas_types.Class) -> Iterator[Error]:
     yield from _TRANSFORMER.transform(that)
 
 
+def verify_xml_serializable_string(that: str) -> Iterator[Error]:
+    """Verify the constraints of :paramref:`that`."""
+    if not matches_xml_serializable_string(that):
+        yield Error(
+            "Constraint AASd-130: An attribute with data type 'string' "
+            + "shall consist of these characters only: "
+            + "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$."
+        )
+
+
 def verify_non_empty_xml_serializable_string(that: str) -> Iterator[Error]:
     """Verify the constraints of :paramref:`that`."""
     if not matches_xml_serializable_string(that):
@@ -6038,16 +6048,14 @@ def verify_qualifier_type(that: str) -> Iterator[Error]:
         yield Error("Name type shall have a maximum length of 128 characters.")
 
 
-# noinspection PyUnusedLocal
 def verify_value_data_type(that: str) -> Iterator[Error]:
     """Verify the constraints of :paramref:`that`."""
-    # There is no verification specified.
-    return
-
-    # Empty generator according to:
-    # https://stackoverflow.com/a/13243870/1600678
-    # noinspection PyUnreachableCode
-    yield
+    if not matches_xml_serializable_string(that):
+        yield Error(
+            "Constraint AASd-130: An attribute with data type 'string' "
+            + "shall consist of these characters only: "
+            + "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$."
+        )
 
 
 def verify_id_short_type(that: str) -> Iterator[Error]:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ pylint==2.15.4
 coverage>=6.5.0,<7
 pyinstaller>=5,<6
 twine
-aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@77d3442#egg=aas-core-meta
-aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@4433d092#egg=aas-core-codegen
+aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@f2fd738#egg=aas-core-meta
+aas-core-codegen@git+https://github.com/aas-core-works/aas-core-codegen@c77b7dc6#egg=aas-core-codegen

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_02.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_03.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_07.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_08.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Any_URI/negatively_fuzzed_09.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_01.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_02.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_07.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Base_64_binary/negatively_fuzzed_09.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_02.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_04.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_06.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_07.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_08.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/Boolean/negatively_fuzzed_09.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/NUL_as_utf16.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/NUL_as_utf16.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/NUL_as_utf32.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/NUL_as_utf32.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/NUL_as_x.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/NUL_as_x.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_01.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_02.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_03.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_04.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_05.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_06.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_07.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_08.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_09.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidMinMaxExample/Range/String/negatively_fuzzed_10.json.errors
@@ -1,2 +1,4 @@
 .submodels[0].submodel_elements[0]: Max must be consistent with the value type.
 .submodels[0].submodel_elements[0]: Min must be consistent with the value type.
+.submodels[0].submodel_elements[0].min: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.
+.submodels[0].submodel_elements[0].max: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_03.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_08.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Any_URI/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_01.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Base_64_binary/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_04.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_06.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_08.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/Boolean/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/NUL_as_utf16.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/NUL_as_utf16.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/NUL_as_utf32.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/NUL_as_utf32.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/NUL_as_x.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/NUL_as_x.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_01.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_03.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_04.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_05.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_06.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_08.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Extension/String/negatively_fuzzed_10.json.errors
@@ -1,1 +1,2 @@
 .asset_administration_shells[0].extensions[0]: The value must match the value type.
+.asset_administration_shells[0].extensions[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Any_URI/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Any_URI/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Any_URI/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Any_URI/negatively_fuzzed_03.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Any_URI/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Any_URI/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Any_URI/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Any_URI/negatively_fuzzed_08.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Any_URI/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Any_URI/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_01.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Base_64_binary/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_04.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_06.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_08.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/Boolean/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/NUL_as_utf16.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/NUL_as_utf16.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/NUL_as_utf32.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/NUL_as_utf32.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/NUL_as_x.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/NUL_as_x.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_01.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_03.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_04.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_05.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_06.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_08.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Property/String/negatively_fuzzed_10.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].submodel_elements[0]: Value must be consistent with the value type.
+.submodels[0].submodel_elements[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_03.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_08.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Any_URI/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_01.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Base_64_binary/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_04.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_06.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_08.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/Boolean/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/NUL_as_utf16.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/NUL_as_utf16.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/NUL_as_utf32.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/NUL_as_utf32.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/NUL_as_x.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/NUL_as_x.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_01.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_01.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_02.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_02.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_03.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_03.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_04.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_04.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_05.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_05.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_06.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_06.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_07.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_07.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_08.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_08.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_09.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_09.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.

--- a/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_10.json.errors
+++ b/test_data/Json/ContainedInEnvironment/Unexpected/Invalid/InvalidValueExample/Qualifier/String/negatively_fuzzed_10.json.errors
@@ -1,1 +1,2 @@
 .submodels[0].qualifiers[0]: Constraint AASd-020: The value shall be consistent to the data type as defined in value type.
+.submodels[0].qualifiers[0].value: Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\U00010000-\U0010FFFF]*$.


### PR DESCRIPTION
We update the development requirements to and re-generate everything with:
* [aas-core-meta f2fd738],
* [aas-core-codegen c77b7dc6] and
* [aas-core3.0-testgen a8c4155e4].

Notably, we propagate all the fixes for V3.0.2.

[aas-core-meta f2fd738]: https://github.com/aas-core-works/aas-core-meta/commit/f2fd738
[aas-core-codegen c77b7dc6]: https://github.com/aas-core-works/aas-core-codegen/commit/c77b7dc6
[aas-core3.0-testgen a8c4155e4]: https://github.com/aas-core-works/aas-core3.0-testgen/commit/a8c4155e4