### PR TITLE
Deprecate Python 3.7 and add 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.11']
+        python-version: ['3.8', '3.9', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@master

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,11 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     license="License :: OSI Approved :: MIT License",
     keywords="asset administration shell sdk industry 4.0 industrie i4.0 industry iot iiot",


### PR DESCRIPTION
The CI on GitHub does not support Python 3.7 any more, so we deprecate it as we can not test locally.

At the same time, we add Python 3.12 as it reached maturity.