### PR TITLE
Release 1.1.3

### DIFF
--- a/aas_core3/__init__.py
+++ b/aas_core3/__init__.py
@@ -1,7 +1,7 @@
 """Manipulate, verify and de/serialize Asset Administration Shells."""
 
 # Synchronize with __init__.py and changelog.rst!
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __author__ = "Marko Ristin"
 __copyright__ = "2024 Contributors to aas-core3.0-python"
 __license__ = "License :: OSI Approved :: MIT License"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,13 @@
 **********
 Change Log
 **********
+1.1.3 (2025-10-27)
+==================
+We propagate a fix for references index constraint where indices in references
+were erroneously assumed to be positive integers; please refer to:
+
+* https://github.com/aas-core-works/aas-core-meta/pull/370
+
 1.1.2 (2025-05-13)
 ==================
 We propagate the changes and fixes for V3.0.2; please refer to:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="aas-core3.0",
     # Synchronize with __init__.py and changelog.rst!
-    version="1.1.2",
+    version="1.1.3",
     description="Manipulate, verify and de/serialize Asset Administration Shells.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core3.0-python",


### PR DESCRIPTION
We propagate a fix for references index constraint where indices in references
were erroneously assumed to be positive integers; please refer to:

* https://github.com/aas-core-works/aas-core-meta/pull/370